### PR TITLE
Add Dockerfile for building/running ScarletDME under Docker

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,21 @@
+30May20 -Simon Kissane
+----------------------
+Add Dockerfile for building/running ScarletDME under Docker
+
+Usage:
+
+./docker/run
+
+At root@XXXXXXXXXXXX:/usr/qmsys# prompt, run:
+   ./bin/qm -start
+   ./bin/qm
+
+This is useful for people who run macOS who want an easy way of
+building/running 32-bit Linux ScarletDME under Docker for Mac. (It could
+also be useful for people who run Linux but may not have the right
+development packages installed - the Dockerfile installs the necessary
+packages automatically.)
+
 28Feb20, 29Feb20 -gwb
 ---------------------
 ScarletDME now builds as a 64 bit application without error and will properly

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN mkdir /usr/src/ScarletDME && \
+	dpkg --add-architecture i386 && \
+	apt-get update && \
+	apt-get install -y gcc-multilib make libcrypt-dev:i386 && \
+	groupadd qmusers && \
+	useradd -G qmusers -d /usr/qmsys qmsys
+COPY / /usr/src/ScarletDME
+RUN chown -R qmsys:qmusers /usr/src/ScarletDME
+RUN (mkdir /usr/qmsys && chown -R qmsys:qmusers /usr/qmsys)
+RUN cp /usr/src/ScarletDME/qmconfig /etc/scarlet.conf
+RUN chown qmsys:qmusers /etc/scarlet.conf
+RUN usermod -a -G qmusers root
+USER qmsys:qmusers
+RUN (cd /usr/src/ScarletDME && (make clean || true))
+RUN (cd /usr/src/ScarletDME && make && make install datafiles)
+WORKDIR /usr/qmsys
+USER root:root

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Script to build and run Docker container for ScarletDME development.
+#
+set -ue
+cd "$(dirname "$0")"
+docker build -f ./Dockerfile -t scarletdme ..
+docker run -it scarletdme /bin/bash


### PR DESCRIPTION
Usage:
```
./docker/run
```

At root@XXXXXXXXXXXX:/usr/qmsys# prompt, run:
```
   ./bin/qm -start
   ./bin/qm
```

This is useful for people who run macOS who want an easy way of
building/running 32-bit Linux ScarletDME under Docker for Mac. (It could
also be useful for people who run Linux but may not have the right
development packages installed - the Dockerfile installs the necessary
packages automatically.)