### PR TITLE
Create pid file on start and update systemd service to start and stop ScarletDME properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ QMUSERS := $(shell cat /etc/group | grep qmusers)
 qm: ARCH :=
 qm: BITSIZE := 64
 qm: C_FLAGS  := -Wall -Wformat=2 -Wno-format-nonliteral -DLINUX -D_FILE_OFFSET_BITS=64 -I$(GPLSRC) -DGPL -g $(ARCH) -fPIE
-qm: $(QMOBJS) qmclilib.so qmtic qmfix qmconv qmidx qmlnxd terminfo
+qm: $(QMOBJS) qmclilib.so qmtic qmfix qmconv qmidx qmlnxd
 	@echo Linking $@
 	@cd $(GPLOBJ)
 	@$(COMP) $(ARCH) $(L_FLAGS) $(QMOBJSD) -o $(GPLBIN)qm
@@ -135,7 +135,7 @@ qm: $(QMOBJS) qmclilib.so qmtic qmfix qmconv qmidx qmlnxd terminfo
 qm32: ARCH := -m32
 qm32: BITSIZE := 32
 qm32: C_FLAGS  := -Wall -Wformat=2 -Wno-format-nonliteral -DLINUX -D_FILE_OFFSET_BITS=64 -I$(GPLSRC) -DGPL -g $(ARCH)
-qm32: $(QMOBJS) qmclilib.so qmtic qmfix qmconv qmidx qmlnxd terminfo
+qm32: $(QMOBJS) qmclilib.so qmtic qmfix qmconv qmidx qmlnxd
 	@echo Linking $@
 	@$(COMP) $(ARCH) $(L_FLAGS) $(QMOBJSD) -o $(GPLBIN)qm
 
@@ -231,7 +231,8 @@ endif
 endif
 
 	@echo Compiling terminfo library
-	@test -d qmsys/terminfo || mkdir qmsys/terminfo
+	@test -d qmsys/terminfo && rm -Rf qmsys/terminfo
+	@mkdir qmsys/terminfo
 	cd qmsys && $(GPLBIN)qmtic -pterminfo $(MAIN)terminfo.src
 
 	@echo Installing to $(INSTROOT)
@@ -259,8 +260,9 @@ else
 #	copy the contents of terminfo so the account will upgrade
 	@rm -Rf $(INSTROOT)/terminfo/*
 	@cp -R qmsys/terminfo/* $(INSTROOT)/terminfo
-	@chown qmsys:qmusers $(INSTROOT)/terminfo/*
-	@chmod 664 $(INSTROOT)/terminfo/*
+	@chown -R qmsys:qmusers $(INSTROOT)/terminfo
+	@find $(INSTROOT)/terminfo -type d -print0 | xargs -0 chmod 775
+	@find $(INSTROOT)/terminfo -type f -print0 | xargs -0 chmod 664
 
 endif
 #       copy bin files and make them executable

--- a/gplsrc/config.c
+++ b/gplsrc/config.c
@@ -63,31 +63,32 @@
  *
  * Handles parsing of the configuration file.
  * 
- *  DEADLOCK=n    Trap deadlocks?
- *  DEBUG=n       Debug features enabled? (bit flags)
- *  FDS=n         Set FDS limit (default is no limit)
- *  FLTDIFF=f     Wide zero value
- *  GDI=n         Select default API calls for printing
- *  GRPSIZE=n     Default group size when creating a dynamic file
- *  MAXIDLEN=63   Maximum record id len
- *  MUSTLOCK=1    Must hold update or file lock to write or delete record
- *  NETFILES=0    Allow remote files?
- *                  0x0001   Allow outgoing NFS
- *                  0x0002   Allow incoming QMNet
- *  NUMFILES=n    Maximum number of files open (all users)
- *  NUMLOCKS=n    Maximum number of record locks
- *  OBJECTS=n     Limit on loaded object code count (0 = no limit)
- *  OBJMEM=n      Limit on locade object size (kb, 0 = no limit)
- *  QMCLIENT=n    QMClient rules (0=all, 1=no call/exec, 2=restricted call)
- *  QMSYS=path    QMSYS directory path
- *  SAFEDIR=1     Use careful update to directory files
- *  SORTMEM=n     Threshold for disk based sort (units of 1kb)
- *  SORTWORK=path Pathname of sort workfile directory
- *  STARTUP=cmd   Run command on starting QM
- *  TEMPDIR=path  Pathname of temporary directory
- *  TERMINFO=path Pathname of terminfo directory
- *  TXCHAR=1      Enable ansi/oem character translation (default = 1)
- *  YEARBASE=n    Two digit year base (default = 1930)
+ *  DEADLOCK=n       Trap deadlocks?
+ *  DEBUG=n          Debug features enabled? (bit flags)
+ *  FDS=n            Set FDS limit (default is no limit)
+ *  FLTDIFF=f        Wide zero value
+ *  GDI=n            Select default API calls for printing
+ *  GRPSIZE=n        Default group size when creating a dynamic file
+ *  MAXIDLEN=63      Maximum record id len
+ *  MUSTLOCK=1       Must hold update or file lock to write or delete record
+ *  NETFILES=0       Allow remote files?
+ *                     0x0001   Allow outgoing NFS
+ *                     0x0002   Allow incoming QMNet
+ *  NUMFILES=n       Maximum number of files open (all users)
+ *  NUMLOCKS=n       Maximum number of record locks
+ *  OBJECTS=n        Limit on loaded object code count (0 = no limit)
+ *  OBJMEM=n         Limit on locade object size (kb, 0 = no limit)
+ *  PIDFILE=filepath Replace the default file path containing qnlnxd process id, used by systemctl to check whether ScarletDME is started or not
+ *  QMCLIENT=n       QMClient rules (0=all, 1=no call/exec, 2=restricted call)
+ *  QMSYS=path       QMSYS directory path
+ *  SAFEDIR=1        Use careful update to directory files
+ *  SORTMEM=n        Threshold for disk based sort (units of 1kb)
+ *  SORTWORK=path    Pathname of sort workfile directory
+ *  STARTUP=cmd      Run command on starting QM
+ *  TEMPDIR=path     Pathname of temporary directory
+ *  TERMINFO=path    Pathname of terminfo directory
+ *  TXCHAR=1         Enable ansi/oem character translation (default = 1)
+ *  YEARBASE=n       Two digit year base (default = 1930)
  *
  *
  * END-DESCRIPTION
@@ -134,10 +135,10 @@ struct CONFIG* read_config(char* errmsg) {
   /* Set defaults for private configuration parameters */
   /* !!CONFIG!! */
 
-  pcfg.codepage = 0;      /* CODEPAGE: Console code page */
-  pcfg.dumpdir[0] = '\0'; /* DUMPDIR:  Directory for process dump files */
-  pcfg.exclrem = 0;       /* EXCLREM:  Exclude remote files in ACCOUNT.SAVE? */
-  pcfg.filerule = 0;      /* FILERULE: File name rules (special forms) */
+  pcfg.codepage = 0;              /* CODEPAGE: Console code page */
+  pcfg.dumpdir[0] = '\0';         /* DUMPDIR:  Directory for process dump files */
+  pcfg.exclrem = 0;               /* EXCLREM:  Exclude remote files in ACCOUNT.SAVE? */
+  pcfg.filerule = 0;              /* FILERULE: File name rules (special forms) */
   pcfg.fltdiff = 0.0000000000291; /* FLTDIFF: Wide zero for float eq test */
   pcfg.fsync = 0;                 /* FSYNC:    Controls when to do fsync() */
   pcfg.gdi = 0;                   /* GDI:      Default GDI spool API? */
@@ -152,17 +153,17 @@ struct CONFIG* read_config(char* errmsg) {
   pcfg.qmclient_mode = 0;         /* QMCLIENT: Client capabilities */
   pcfg.reccache = 0;              /* RECCACHE: Record cache size */
   pcfg.ringwait = TRUE;           /* RINGWAIT: Wait if ring buffer full */
-  pcfg.safedir = FALSE;       /* SAFE_DIR: User careful update to dir files */
-  pcfg.sh[0] = '\0';          /* SH:       Command to run interactive shell */
-  pcfg.sh1[0] = '\0';         /* SH1:      Command to run single shell */
-  pcfg.sortmem = 1048576;     /* SORTMEM:  1Mb default switch to disk sort */
-  pcfg.sortmrg = 4;           /* SORTMRG:  Files merged in one pass */
-  pcfg.sortworkdir[0] = '\0'; /* SORTWORK: Use QMSYS directory */
-  pcfg.tempdir[0] = '\0';     /* TEMPDIR:  Temporary directory */
-  pcfg.spooler[0] = '\0';     /* SPOOLER:  Default spooler name */
-  pcfg.terminfodir[0] = '\0'; /* TERMINFO: Use default location */
-  pcfg.txchar = TRUE;         /* TXCHAR:   Enable ansi/oem translation */
-  pcfg.yearbase = 1930;       /* YEARBASE: Two digit year base */
+  pcfg.safedir = FALSE;           /* SAFE_DIR: User careful update to dir files */
+  pcfg.sh[0] = '\0';              /* SH:       Command to run interactive shell */
+  pcfg.sh1[0] = '\0';             /* SH1:      Command to run single shell */
+  pcfg.sortmem = 1048576;         /* SORTMEM:  1Mb default switch to disk sort */
+  pcfg.sortmrg = 4;               /* SORTMRG:  Files merged in one pass */
+  pcfg.sortworkdir[0] = '\0';     /* SORTWORK: Use QMSYS directory */
+  pcfg.tempdir[0] = '\0';         /* TEMPDIR:  Temporary directory */
+  pcfg.spooler[0] = '\0';         /* SPOOLER:  Default spooler name */
+  pcfg.terminfodir[0] = '\0';     /* TERMINFO: Use default location */
+  pcfg.txchar = TRUE;             /* TXCHAR:   Enable ansi/oem translation */
+  pcfg.yearbase = 1930;           /* YEARBASE: Two digit year base */
 
   /* Set any non-zero defaults for shared configuration parameters */
 
@@ -256,7 +257,13 @@ struct CONFIG* read_config(char* errmsg) {
         pcfg.objmem = n * 1024L;
       else if (sscanf(rec, "PDUMP=%d", &n) == 1)
         cfg->pdump |= n;
-      else if (sscanf(rec, "PORTMAP=%d,%d,%d", &n, &n2, &n3) == 3) {
+      else if (strncmp(rec, "PIDFILE=", 8) == 0) {
+        if (strlen (rec) - 8 > MAX_PATHNAME_LEN) {
+          sprintf(errmsg, "PIDFILE file name too long");
+          goto exit_read_config;
+        }
+        strcpy(cfg->pid_file_path, rec + 8);
+      } else if (sscanf(rec, "PORTMAP=%d,%d,%d", &n, &n2, &n3) == 3) {
         cfg->portmap_base_port = n;
         cfg->portmap_base_user = n2;
         cfg->portmap_range = n3;

--- a/gplsrc/config.h
+++ b/gplsrc/config.h
@@ -61,28 +61,29 @@
 
 struct CONFIG {
  
-  int16_t max_users;               /* User limit */
+  int16_t max_users;                      /* User limit */
   char sysdir[MAX_PATHNAME_LEN+1];
-  int16_t cmdstack;                /* CMDSTACK: Command stack depth */
-  bool deadlock;                   /* DEADLOCK: Trap deadlocks */
-  u_int16_t debug;                 /* DEBUG:    Controls debug features */
-  int errlog;                      /* ERRLOG:   Max errlog size in bytes, 0 if disabled */
-  int16_t fds_limit;               /* FDS */
-  int16_t fixusers_base;           /* FIXUSERS: First user number and... */
-  int16_t fixusers_range;          /*          ...Number of users */
-  int16_t jnlmode;                 /* JNLMODE:  Journalling mode */
-  char jnldir[MAX_PATHNAME_LEN+1]; /* JNLDIR:   Journal file directory */
-  int16_t maxidlen;                /* MAXIDLEN: Maximum record id length */
-  int16_t netfiles;                /* NETFILES:
-                                      0x0001    Allow outgoing NFS
-                                      0x0002    Allow incoming QMNet   */
-  int16_t numfiles;                /* NUMFILES: Maximum number of files open */
-  int16_t numlocks;                /* NUMLOCKS: Maximum number of record locks */
-  int16_t pdump;                   /* PDUMP:    PDUMP mode flags */
-  int16_t portmap_base_port;       /* PORTMAP: First port number ... */
-  int16_t portmap_base_user;       /*          ...First user number... */
-  int16_t portmap_range;           /*          ...Number of ports/users */
-  char startup[80+1];              /* STARTUP: Startup command */
+  int16_t cmdstack;                       /* CMDSTACK: Command stack depth */
+  bool deadlock;                          /* DEADLOCK: Trap deadlocks */
+  u_int16_t debug;                        /* DEBUG:    Controls debug features */
+  int errlog;                             /* ERRLOG:   Max errlog size in bytes, 0 if disabled */
+  int16_t fds_limit;                      /* FDS */
+  int16_t fixusers_base;                  /* FIXUSERS: First user number and... */
+  int16_t fixusers_range;                 /*          ...Number of users */
+  int16_t jnlmode;                        /* JNLMODE:  Journalling mode */
+  char jnldir[MAX_PATHNAME_LEN+1];        /* JNLDIR:   Journal file directory */
+  int16_t maxidlen;                       /* MAXIDLEN: Maximum record id length */
+  int16_t netfiles;                       /* NETFILES:
+                                             0x0001    Allow outgoing NFS
+                                             0x0002    Allow incoming QMNet   */
+  int16_t numfiles;                       /* NUMFILES: Maximum number of files open */
+  int16_t numlocks;                       /* NUMLOCKS: Maximum number of record locks */
+  int16_t pdump;                          /* PDUMP:    PDUMP mode flags */
+  int16_t portmap_base_port;              /* PORTMAP: First port number ... */
+  int16_t portmap_base_user;              /*          ...First user number... */
+  int16_t portmap_range;                  /*          ...Number of ports/users */
+  char pid_file_path[MAX_PATHNAME_LEN+1]; /* PIDFILE:  Replace the default file path containing qnlnxd process id, used by systemctl to check whether ScarletDME is started or not */
+  char startup[80+1];                     /* STARTUP: Startup command */
  };
 
 

--- a/gplsrc/sysseg.h
+++ b/gplsrc/sysseg.h
@@ -111,6 +111,7 @@ struct SYSSEG {
    int32_t pcode_offset;        /* Pcode */
    int32_t pcfg_offset;         /* Offset to template pcfg structure */
    int pcode_len;
+   char pid_file_path[MAX_PATHNAME_LEN+1]; /* PIDFILE:  Replace the default file path containing qnlnxd process id, used by systemctl to check whether ScarletDME is started or not */
 };
 
 Public SYSSEG * sysseg init(NULL);   /* 0234 */

--- a/usr/lib/systemd/system/scarletdme.service
+++ b/usr/lib/systemd/system/scarletdme.service
@@ -4,8 +4,8 @@ Description=ScarletDME service start
 [Service]
 Type=forking
 ExecStart=/usr/bin/qm -start
-# This should be here but currently seems to crash things ...
-# ExecStop=/usr/bin/qm -stop
+ExecStop=/usr/bin/qm -stop
+PIDFile=/run/scarletdme.pid
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
To use a systemd service in "forking" mode, it is necessary to create a pid file. This change contains code to create this file and an update to the service definition. ScarletDME can now start and stop correctly. The pid filename can modify in /etc/scarlet.conf file.