### PR TITLE
BCOMP bug and DTX function fix

### DIFF
--- a/gplsrc/op_misc.c
+++ b/gplsrc/op_misc.c
@@ -21,6 +21,8 @@
  * ScarletDME Wiki: https://scarlet.deltasoft.com
  * 
  * START-HISTORY (ScarletDME):
+ * 13Oct24 mab Correct format code for op_dtx (BASIC DTX()) 
+ *
  * 09Jan22 gwb Fixed a cast warning. (search for 09Jan22 for details)
  *             Fixed a format specifier warning.
  *
@@ -302,7 +304,8 @@ void op_dtx() {
 
   descr = e_stack - 1;
   GetInt(descr);
-  n = sprintf(value, "%d", descr->data.value);
+  /* 13Oct24 mab correct format code */
+  n = sprintf(value, "%x", descr->data.value);
 
   p = s;
   if (n < min_width) {

--- a/qmsys/GPL.BP/BCOMP
+++ b/qmsys/GPL.BP/BCOMP
@@ -19,6 +19,7 @@
 * Ladybridge Systems can be contacted via the www.openqm.com web site.
 * 
 * START-HISTORY:
+* 13 Oct 24 mab(njs) correct len of function.args test in ST.DEFFUN (len() missing)
 * 05 May 22 NJS convert mode.names to use @VM not hard coded hex fd
 *           NJS convert various local reserved.names<2> to use @VM not hard coded hex fd
 * 18 Mar 22 rdm Added OPTIONAL.THEN.ELSE mode.
@@ -6900,8 +6901,8 @@ st.deffun:
       err.msg = sysmsg(2898) ;* Too many arguments is function definition
       goto error
    end
-
-   if function.args > greatest.call.arg.count then
+* 13 Oct 24 mab mab len() of function.args missing 
+   if len(function.args) > greatest.call.arg.count then
       greatest.call.arg.count = len(function.args)
    end
 


### PR DESCRIPTION
Fix following:
BCOMP -  correct length of function.args test in ST.DEFFUN (len() missing) op_misc.c - function op_dtx() BASIC function DTX(). Wrong format code change %d to %x. Please note: I have not rebuilt ScarletDME with these changes, errors were found while working on sd (string database port).  Provided here for reference.