### PR TITLE
Fix install to work with empty bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,8 +267,8 @@ else
 endif
 #       copy bin files and make them executable
 	@test -d $(INSTROOT)/bin || mkdir $(INSTROOT)/bin
-#	copy the contents of bin so the account will upgrade
-	@rm $(INSTROOT)/bin/*
+#	copy the contents of bin so the account will upgrade - -f so it works on an empty directory
+	@rm -f $(INSTROOT)/bin/*
 	@cp bin/* $(INSTROOT)/bin
 	chown qmsys:qmusers $(INSTROOT)/bin $(INSTROOT)/bin/*
 	chmod 775 $(INSTROOT)/bin $(INSTROOT)/bin/*


### PR DESCRIPTION
It's been there a while, but should fix a problem with an empty bin directory. I thought I'd generated a pull request ages ago, so I can't quite remember what the problem was ...